### PR TITLE
Move choice of the effect for dispatcher to the client.

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -44,11 +44,10 @@ trait Reduce[M[_]] {
 
 object Reduce {
 
-  class DebruijnInterpreter[M[_]: InterpreterErrorsM, F[_]](
+  class DebruijnInterpreter[M[_]: InterpreterErrorsM: Capture, F[_]](
       tupleSpace: IStore[Channel, BindPattern, Seq[Channel], TaggedContinuation],
       dispatcher: => Dispatch[M, Seq[Channel], TaggedContinuation])(
-      implicit parallel: cats.Parallel[M, F],
-      captureM: Capture[M])
+      implicit parallel: cats.Parallel[M, F])
       extends Reduce[M] {
 
     type Cont[Data, Body] = (Body, Env[Data])

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Runtime.scala
@@ -10,7 +10,7 @@ import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models.{BindPattern, Channel, TaggedContinuation, Var}
 import coop.rchain.rholang.interpreter.implicits._
 import coop.rchain.rholang.interpreter.storage.implicits._
-import coop.rchain.rspace.{IStore, LMDBStore, install}
+import coop.rchain.rspace.{install, IStore, LMDBStore}
 import monix.eval.Task
 
 import scala.collection.immutable
@@ -51,7 +51,7 @@ object Runtime {
         .create[Channel, BindPattern, Seq[Channel], TaggedContinuation](dataDir, mapSize)
 
     lazy val dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation] =
-      RholangAndScalaDispatcher.create(store, dispatchTable)
+      Dispatch.rholangAndScalaDispatcher[Task, Task.Par](store, dispatchTable)
 
     lazy val dispatchTable = Map(
       0L -> SystemProcesses.stdout,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/dispatch.scala
@@ -1,12 +1,12 @@
 package coop.rchain.rholang.interpreter
 
+import cats.Applicative
 import coop.rchain.catscontrib.Capture
 import coop.rchain.models.Channel.ChannelInstance.Quote
 import coop.rchain.models.TaggedContinuation.TaggedCont.{Empty, ParBody, ScalaBodyRef}
 import coop.rchain.models.{BindPattern, Channel, Par, TaggedContinuation}
+import coop.rchain.rholang.interpreter.errors._
 import coop.rchain.rspace.IStore
-import monix.eval.Task
-import monix.eval.Task.catsParallel
 
 trait Dispatch[M[_], A, K] {
 
@@ -20,68 +20,58 @@ object Dispatch {
   // TODO: Make this function total
   def buildEnv(dataList: Seq[Seq[Channel]]): Env[Par] =
     Env.makeEnv(dataList.flatten.map({ case Channel(Quote(p)) => p }): _*)
-}
 
-class RholangOnlyDispatcher private (_reducer: => Reduce[Task])
-    extends Dispatch[Task, Seq[Channel], TaggedContinuation] {
+  //TODO(mateusz.gorski): Move to test directory
+  def rholangOnlyDispatcher[M[_]: Applicative: Capture: InterpreterErrorsM, F[_]](
+      tuplespace: IStore[Channel, BindPattern, Seq[Channel], TaggedContinuation])(
+      implicit parallel: cats.Parallel[M, F]): Dispatch[M, Seq[Channel], TaggedContinuation] = {
+    lazy val dispatcher: Dispatch[M, Seq[Channel], TaggedContinuation] =
+      new Dispatch[M, Seq[Channel], TaggedContinuation] {
+        val reducer: Reduce[M] = _reducer
 
-  val reducer: Reduce[Task] = _reducer
+        def dispatch(continuation: TaggedContinuation, dataList: Seq[Seq[Channel]]): M[Unit] =
+          continuation.taggedCont match {
+            case ParBody(par) =>
+              val env = Dispatch.buildEnv(dataList)
+              reducer.eval(par)(env)
+            case ScalaBodyRef(_) =>
+              Applicative[M].pure(Unit)
+            case Empty =>
+              Applicative[M].pure(Unit)
+          }
+      }
 
-  def dispatch(continuation: TaggedContinuation, dataList: Seq[Seq[Channel]]): Task[Unit] =
-    continuation.taggedCont match {
-      case ParBody(par) =>
-        val env = Dispatch.buildEnv(dataList)
-        reducer.eval(par)(env)
-      case ScalaBodyRef(_) =>
-        Task.unit
-      case Empty =>
-        Task.unit
-    }
-}
+    lazy val _reducer: Reduce[M] =
+      new Reduce.DebruijnInterpreter[M, F](tuplespace, dispatcher)
 
-object RholangOnlyDispatcher {
-
-  def create(tuplespace: IStore[Channel, BindPattern, Seq[Channel], TaggedContinuation])(
-      implicit captureTask: Capture[Task]): Dispatch[Task, Seq[Channel], TaggedContinuation] = {
-    lazy val dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation] =
-      new RholangOnlyDispatcher(reducer)
-    lazy val reducer: Reduce[Task] =
-      new Reduce.DebruijnInterpreter[Task, Task.Par](tuplespace, dispatcher)
     dispatcher
   }
-}
 
-class RholangAndScalaDispatcher private (
-    _reducer: => Reduce[Task],
-    _dispatchTable: => Map[Long, Function1[Seq[Seq[Channel]], Task[Unit]]])
-    extends Dispatch[Task, Seq[Channel], TaggedContinuation] {
+  def rholangAndScalaDispatcher[M[_]: Applicative: Capture: InterpreterErrorsM, F[_]](
+      tuplespace: IStore[Channel, BindPattern, Seq[Channel], TaggedContinuation],
+      dispatchTable: => Map[Long, Function1[Seq[Seq[Channel]], M[Unit]]])(
+      implicit parallel: cats.Parallel[M, F]): Dispatch[M, Seq[Channel], TaggedContinuation] = {
 
-  val reducer: Reduce[Task] = _reducer
+    lazy val dispatcher: Dispatch[M, Seq[Channel], TaggedContinuation] =
+      new Dispatch[M, Seq[Channel], TaggedContinuation] {
+        val reducer: Reduce[M] = _reducer
 
-  def dispatch(continuation: TaggedContinuation, dataList: Seq[Seq[Channel]]): Task[Unit] =
-    continuation.taggedCont match {
-      case ParBody(par) =>
-        val env = Dispatch.buildEnv(dataList)
-        reducer.eval(par)(env)
-      case ScalaBodyRef(ref) =>
-        _dispatchTable.get(ref) match {
-          case Some(f) => f(dataList)
-          case None    => Task.raiseError(new Exception(s"dispatch: no function for $ref"))
-        }
-      case Empty =>
-        Task.unit
-    }
-}
+        def dispatch(continuation: TaggedContinuation, dataList: Seq[Seq[Channel]]): M[Unit] =
+          continuation.taggedCont match {
+            case ParBody(par) =>
+              val env = Dispatch.buildEnv(dataList)
+              reducer.eval(par)(env)
+            case ScalaBodyRef(_) =>
+              Applicative[M].pure(Unit)
+            case Empty =>
+              Applicative[M].pure(Unit)
+          }
+      }
 
-object RholangAndScalaDispatcher {
+    lazy val _reducer: Reduce[M] =
+      new Reduce.DebruijnInterpreter[M, F](tuplespace, dispatcher)
 
-  def create(tuplespace: IStore[Channel, BindPattern, Seq[Channel], TaggedContinuation],
-             dispatchTable: => Map[Long, Function1[Seq[Seq[Channel]], Task[Unit]]])(
-      implicit captureTask: Capture[Task]): Dispatch[Task, Seq[Channel], TaggedContinuation] = {
-    lazy val dispatcher: Dispatch[Task, Seq[Channel], TaggedContinuation] =
-      new RholangAndScalaDispatcher(reducer, dispatchTable)
-    lazy val reducer: Reduce[Task] =
-      new Reduce.DebruijnInterpreter[Task, Task.Par](tuplespace, dispatcher)
     dispatcher
+
   }
 }


### PR DESCRIPTION
I refactored the `Dispatch` so it pushes the choice of effect to the declaration. I made it because I wanted to see how the code will be affected and I think this doesn't look neither much better nor much worse but this way we stick to more consistent approach of using _"tagless final"_ style throughout the code base. There are still four tests failing so this needs to be taken care of before merging to `rchain:dev`. I don't know why they fail yet because I haven't touched parts that could break them. I will look into it soon but firstly wanted to know your opinion on that.